### PR TITLE
Update controller role

### DIFF
--- a/installation/kubevirt-cluster.yaml
+++ b/installation/kubevirt-cluster.yaml
@@ -9,7 +9,7 @@ spec:
       user: ubuntu
       port: 22
       keyPath: /Users/kng/Kevin/Work/Mirantis/Demo/certs/kng-msr.pem
-    role: controller
+    role: controller+worker
   - ssh:
       address: 54.87.148.11
       user: ubuntu


### PR DESCRIPTION
Deployment of virt-operator looks for the label node-role.kubernetes.io/control-plane. However, in k0s a controller doesn't have the node-role.kubernetes.io/control-plane label without the --enable-worker flag. Changed role to be controller+worker.